### PR TITLE
fix: correctly parse partOfSpeech from API response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.cursor/

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ struct Phonetic {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Meaning {
     part_of_speech: Option<String>,
     definitions: Vec<Definition>,


### PR DESCRIPTION
## Problem

The `part_of_speech` field was always showing as `unknown` for all words.

## Root Cause

The Free Dictionary API returns field names in camelCase (e.g., `partOfSpeech`), but the `Meaning` struct used snake_case (`part_of_speech`). This caused serde to fail deserializing the field.

**Before:**
```
Part of speech: unknown
  1. The deteriorated state of iron or steel...
```

**After:**
```
Part of speech: noun
  1. The deteriorated state of iron or steel...
```

## Solution

Added `#[serde(rename_all = "camelCase")]` attribute to the `Meaning` struct to properly map the JSON field names to Rust field names.

## Changes

- `src/main.rs`: Added serde rename attribute to `Meaning` struct
- `.gitignore`: Added `.cursor/` to ignore IDE config files