### PR TITLE
feat: add -n/--limit option to control output verbosity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1240,6 +1241,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 colored = "2.0"
+urlencoding = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ struct Cli {
     interactive: bool,
     
     /// Maximum number of definitions to show per part of speech (default: 3, use -d for all)
-    #[arg(short = 'n', long, default_value = "3")]
-    limit: usize,
+    #[arg(short = 'n', long, default_value = "3", value_parser = clap::value_parser!(u64).range(1..))]
+    limit: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -63,8 +63,8 @@ struct License {
 }
 
 async fn lookup_word(word: &str) -> Result<Vec<DictionaryResponse>, Box<dyn std::error::Error>> {
-    let url = format!("https://api.dictionaryapi.dev/api/v2/entries/en/{}"
-, word);
+    let encoded = urlencoding::encode(word);
+    let url = format!("https://api.dictionaryapi.dev/api/v2/entries/en/{}", encoded);
     
     let response = reqwest::get(&url).await?;
     
@@ -96,7 +96,7 @@ struct DisplayOptions {
     /// Show all content (definitions, examples, synonyms, antonyms)
     detailed: bool,
     /// Maximum definitions per part of speech (ignored if detailed is true)
-    limit: usize,
+    limit: u64,
 }
 
 fn display_word_info(response: &DictionaryResponse, options: &DisplayOptions) {
@@ -120,7 +120,7 @@ fn display_word_info(response: &DictionaryResponse, options: &DisplayOptions) {
         
         // Determine how many definitions to show
         let total_defs = meaning.definitions.len();
-        let show_count = if options.detailed { total_defs } else { total_defs.min(options.limit) };
+        let show_count = if options.detailed { total_defs } else { total_defs.min(options.limit as usize) };
         
         for (i, def) in meaning.definitions.iter().take(show_count).enumerate() {
             println!("  {} {}", format!("{}.", i + 1).bright_green(), def.definition.white());
@@ -182,7 +182,9 @@ async fn run_interactive_mode(options: &DisplayOptions) {
     
     loop {
         print!("{} ", "sw>".bright_green().bold());
-        io::stdout().flush().unwrap();
+        if io::stdout().flush().is_err() {
+            break;
+        }
         
         let mut input = String::new();
         match io::stdin().read_line(&mut input) {
@@ -313,6 +315,12 @@ mod tests {
         assert_eq!(cli.word, Some("hello".to_string()));
         assert_eq!(cli.limit, 2);
         assert!(cli.detail); // detail mode ignores limit
+    }
+
+    #[test]
+    fn test_cli_rejects_limit_zero() {
+        let result = Cli::try_parse_from(["sw", "hello", "-n", "0"]);
+        assert!(result.is_err());
     }
 
     // ==================== Exit Command Tests ====================


### PR DESCRIPTION
## Summary
- Add `-n`/`--limit` flag to control the maximum number of definitions shown per part of speech (default: 3, `-d` for all)
- Introduce `DisplayOptions` struct to encapsulate display configuration (`detailed` + `limit`)
- In normal mode, only show example for the first definition; show truncation hint `(+N more, use -d for all)` when definitions are omitted
- Fix URL injection: percent-encode word input using `urlencoding` crate
- Fix `limit=0` edge case: add `value_parser` range constraint to reject values < 1
- Fix potential panic: replace `stdout().flush().unwrap()` with graceful error handling in interactive mode

## Test plan
- [x] All 18 unit tests pass (`cargo test`)
- [x] New `test_cli_rejects_limit_zero` test verifies `-n 0` is rejected
- [x] Existing limit tests cover `-n 5`, `--limit 10`, and `-n 2 -d` combinations
- [ ] Manual: `sw hello` shows max 3 definitions per part of speech
- [ ] Manual: `sw hello -n 1` shows only 1 definition with truncation hint
- [ ] Manual: `sw hello -d` shows all definitions (ignores limit)
- [ ] Manual: `sw -i` interactive mode exits gracefully on broken pipe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-n/--limit` CLI flag to control the maximum number of definitions displayed per part of speech (default: 3)

* **Bug Fixes**
  * Improved error messages and graceful I/O error handling

* **Tests**
  * Added test coverage for limit functionality and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->