### PR TITLE
feat: add -n/--limit option to control definition output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This is a command-line dictionary tool called "SW" (Search Word) written in Rust
 ## Development Commands
 
 ### Building
+
 ```bash
 # Debug build
 cargo build
@@ -21,6 +22,7 @@ cargo build --release --target <target-triple>
 ```
 
 ### Testing
+
 ```bash
 # Run all tests (excluding integration tests that require network)
 cargo test
@@ -33,21 +35,29 @@ cargo test -- --ignored
 ```
 
 ### Running
+
 ```bash
-# Basic word lookup
+# Basic word lookup (shows up to 3 definitions per part of speech by default)
 cargo run -- <word>
 
-# Detailed lookup with synonyms/antonyms
+# Limit definitions per part of speech
+cargo run -- <word> -n 5
+
+# Detailed lookup with all definitions, synonyms/antonyms
 cargo run -- <word> --detail
 
 # Interactive mode
 cargo run -- --interactive
+
+# Interactive mode with detail
+cargo run -- -i -d
 
 # Help
 cargo run -- --help
 ```
 
 ### Installation
+
 ```bash
 # Install via Homebrew (if formula is tapped)
 brew install szupzj18/tap/sw
@@ -59,48 +69,63 @@ cargo install --path .
 ## Code Architecture
 
 ### Single-File Structure
+
 The entire application is contained in `src/main.rs` with the following organization:
 
-1. **CLI Definition** (`Cli` struct) - Uses `clap` for argument parsing with three modes:
+1. **CLI Definition** (`Cli` struct) - Uses `clap` for argument parsing with four options:
    - Single word lookup (`word` argument)
-   - Detailed mode (`-d`/`--detail` flag)
-   - Interactive mode (`-i`/`--interactive` flag)
+   - Detailed mode (`-d`/`--detail` flag) - show all definitions, examples, synonyms, antonyms
+   - Interactive mode (`-i`/`--interactive` flag) - REPL-style continuous queries
+   - Limit (`-n`/`--limit`, default: 3, min: 1) - max definitions per part of speech (ignored in detail mode)
 
 2. **API Data Models** - Serde structs for Free Dictionary API responses:
-   - `DictionaryResponse` - Main response container
-   - `Meaning` - Word meanings with part of speech
-   - `Definition` - Individual definitions with examples
-   - `Phonetic` - Pronunciation information
+   - `DictionaryResponse` - Main response container (includes `license` and `source_urls` fields)
+   - `Meaning` - Word meanings with part of speech (uses `#[serde(rename_all = "camelCase")]`)
+   - `Definition` - Individual definitions with examples, synonyms, antonyms
+   - `Phonetic` - Pronunciation information (text and audio)
+   - `License` - License metadata (name and url)
 
 3. **Core Functions**:
-   - `lookup_word()` - Async HTTP request to API
-   - `display_word_info()` - Colorful terminal formatting
-   - `run_interactive_mode()` - REPL interface
+   - `lookup_word()` - Async HTTP request to API (with URL encoding via `urlencoding`)
+   - `display_word_info()` - Colorful terminal formatting, controlled by `DisplayOptions`
+   - `lookup_and_display()` - Combines lookup and display with error handling
+   - `run_interactive_mode()` - REPL interface with exit command support
+   - `is_exit_command()` - Checks for quit commands (`q`/`quit`/`exit`)
    - `format_list()`/`print_non_empty_list()` - Helper utilities
 
-4. **Comprehensive Tests** - Unit tests cover:
-   - CLI argument parsing
-   - JSON deserialization
-   - Utility functions
+4. **Display Control** (`DisplayOptions` struct):
+   - `detailed: bool` - Whether to show all content
+   - `limit: u64` - Max definitions per part of speech (ignored when `detailed` is true)
+
+5. **Comprehensive Tests** - Unit tests cover:
+   - CLI argument parsing (including `--limit`, `--detail`, `--interactive` combinations)
+   - Exit command validation
+   - Format list utilities
+   - JSON deserialization (full and minimal responses)
    - Integration tests (marked `#[ignore]` for network access)
 
 ### Dependencies
-- `clap` - Command-line argument parsing
-- `reqwest` - HTTP client with async support
-- `tokio` - Async runtime
-- `serde`/`serde_json` - JSON serialization
+
+- `clap` - Command-line argument parsing (with `derive` feature)
+- `reqwest` - HTTP client with async support (with `json` and `blocking` features)
+- `tokio` - Async runtime (with `full` feature)
+- `serde`/`serde_json` - JSON serialization (with `derive` feature)
 - `colored` - Terminal color formatting
+- `urlencoding` - URL encoding for word queries
 
 ## Development Workflow
 
 ### Cursor Rules
+
 The repository includes `.cursor/rules/development.mdc` which requires:
+
 1. **Analysis first** - Understand requirements before coding
 2. **Execution plan** - Provide detailed steps including files to modify, changes, impact, and risks
 3. **Wait for confirmation** - Don't modify code without user approval
 4. **Then execute** - Implement after plan is confirmed
 
 ### Release Process
+
 1. Tag commits with `v*` pattern (e.g., `v0.1.0`)
 2. GitHub Actions automatically builds binaries for:
    - Linux (x86_64)
@@ -108,29 +133,35 @@ The repository includes `.cursor/rules/development.mdc` which requires:
 3. Homebrew formula (`Formula/sw.rb`) is maintained separately
 
 ### Testing Strategy
+
 - Unit tests are fast and don't require network
 - Integration tests are marked with `#[ignore]` and require `-- --ignored` flag
-- Tests cover CLI parsing, JSON deserialization, and utility functions
+- Tests cover CLI parsing (word, detail, interactive, limit, edge cases like limit=0), exit command validation, format list utilities, and JSON deserialization
 - API integration tests verify actual Free Dictionary API responses
 
 ## Key Implementation Details
 
 ### Error Handling
+
 - Uses `Result<T, Box<dyn std::error::Error>>` for API errors
 - User-friendly error messages with colored output
 - Graceful handling of missing API data (optional fields)
 
 ### Async Pattern
+
 - `#[tokio::main]` attribute on main function
 - Async/await pattern for HTTP requests
 - Proper error propagation with `?` operator
 
 ### Terminal Output
+
 - Color-coded output using `colored` crate
 - Different colors for: word, phonetic, part of speech, examples, synonyms, antonyms
 - Clean formatting with proper indentation
 
 ### API Integration
+
 - Uses Free Dictionary API (https://api.dictionaryapi.dev/)
+- URL encodes word queries via `urlencoding` crate
 - Handles array responses (multiple dictionary entries)
 - Parses nested optional fields gracefully

--- a/README.md
+++ b/README.md
@@ -7,24 +7,30 @@ A simple and elegant command-line dictionary tool written in Rust.
 - **Fast word lookup** using the Free Dictionary API
 - **Colorful terminal output** with clear formatting
 - **Detailed information** including phonetics, definitions, examples, synonyms, and antonyms
+- **Interactive mode** for continuous word lookups without restarting
+- **Configurable output** - limit the number of definitions shown per part of speech
 - **Simple usage** with intuitive command-line interface
 
 ## Installation
 
 ### Via Homebrew (Recommended)
+
 ```bash
 brew tap szupzj18/tap
 brew install sw
 ```
 
 ### From Source
+
 1. Clone this repository:
+
 ```bash
 git clone https://github.com/szupzj18/sw.git
 cd sw
 ```
 
 2. Build the project:
+
 ```bash
 cargo build --release
 ```
@@ -36,62 +42,101 @@ cargo build --release
 ### Basic Usage
 
 Look up a word:
+
 ```bash
 sw <word>
 ```
 
 Example:
+
 ```bash
 sw rust
 ```
 
 ### Detailed Information
 
-Use the `-d` or `--detail` flag to get detailed information including synonyms and antonyms:
+Use the `-d` or `--detail` flag to get detailed information including all definitions, examples, synonyms and antonyms:
+
 ```bash
 sw <word> --detail
 # or
 sw <word> -d
 ```
 
-Example:
+### Limit Definitions
+
+By default, up to 3 definitions are shown per part of speech. Use `-n` or `--limit` to change this:
+
 ```bash
-sw rust --detail
+# Show up to 5 definitions per part of speech
+sw <word> -n 5
+
+# Show only 1 definition per part of speech
+sw <word> --limit 1
 ```
+
+### Interactive Mode
+
+Use `-i` or `--interactive` for a REPL-style interface to look up multiple words without restarting:
+
+```bash
+sw -i
+# or combine with detail mode
+sw -i -d
+```
+
+Type `q`, `quit`, or `exit` to leave interactive mode.
 
 ## Examples
 
-### Basic Lookup
-```bash
-$ sw rust
-Looking up: rust
+### Basic Lookup (default: up to 3 definitions)
 
-Word: rust
-Phonetic: /rʌst/
+```bash
+$ sw hello
+Looking up: hello
+
+Word: hello
+Phonetic: /həˈloʊ/
 
 Part of speech: noun
-  1. a red or brown oxide coating on iron or steel caused by the action of oxygen and moisture
-  2. a plant disease that produces a reddish-brown discoloration of leaves and stems; caused by various rust fungi
-  3. the formation of reddish-brown ferric oxides on iron by low-temperature oxidation in the presence of water
+  1. "Hello!" or an equivalent greeting.
+  2. ...  (+1 more, use -d for all)
+
+Part of speech: verb
+  1. To greet with "hello".
 ```
 
 ### Detailed Lookup
-```bash
-$ sw rust --detail
-Looking up: rust
 
-Word: rust
-Phonetic: /rʌst/
+```bash
+$ sw hello --detail
+Looking up: hello
+
+Word: hello
+Phonetic: /həˈloʊ/
 
 Part of speech: noun
-  1. a red or brown oxide coating on iron or steel caused by the action of oxygen and moisture
-     Example: The old car was covered in rust.
-     Synonyms: corrosion, oxidation, tarnish
-     Antonyms: 
-  2. a plant disease that produces a reddish-brown discoloration of leaves and stems; caused by various rust fungi
-     Example: The wheat crop was affected by rust.
-     Synonyms: 
-     Antonyms: 
+  1. "Hello!" or an equivalent greeting.
+  2. A greeting (salutation) said when meeting someone or acknowledging someone's arrival or presence.
+     Example: "Hello, everyone."
+  3. A call for response if it is not clear if anyone is present or listening...
+     Example: "Hello? Is anyone there?"
+  Synonyms: greeting
+```
+
+### Interactive Mode
+
+```bash
+$ sw -i
+🔄 Interactive Mode
+Type a word to look up, or 'q'/'quit'/'exit' to exit.
+
+sw> hello
+Looking up: hello
+...
+
+sw> quit
+Goodbye! 👋
 ```
 
 ## API Source
@@ -103,8 +148,9 @@ This tool uses the [Free Dictionary API](https://dictionaryapi.dev/) which provi
 - `clap` - Command line argument parsing
 - `reqwest` - HTTP client for API requests
 - `tokio` - Async runtime
-- `serde` - JSON serialization/deserialization
+- `serde` / `serde_json` - JSON serialization/deserialization
 - `colored` - Terminal colors and formatting
+- `urlencoding` - URL encoding for word queries
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add `-n`/`--limit` CLI option to control the maximum number of definitions shown per part of speech (default: 3, min: 1). When there are more definitions than the limit, a hint `(+N more, use -d for all)` is displayed. The `-d`/`--detail` flag overrides the limit and shows everything.
- Introduce `DisplayOptions` struct and `urlencoding` dependency to improve code structure and handle special characters in word queries.
- Fix potential panic in interactive mode by gracefully handling `stdout().flush()` errors.
- Update `CLAUDE.md` and `README.md` to document the new `--limit`/`-n` option, interactive mode usage, updated examples, and all current dependencies.

## Test plan

- [x] Unit tests for `--limit` flag parsing (`-n 5`, `--limit 10`, combined with `-d`)
- [x] Unit test verifying `--limit 0` is rejected
- [x] Default limit value is 3 when not specified
- [x] Existing CLI, deserialization, and utility tests still pass
- [ ] Manual: `sw hello` shows at most 3 definitions with overflow hint
- [ ] Manual: `sw hello -n 1` shows only 1 definition per part of speech
- [ ] Manual: `sw hello -d` shows all definitions regardless of limit
- [ ] Manual: `sw -i` interactive mode works with limit and detail options


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily CLI/output behavior changes plus a small refactor and URL-encoding of query strings; main risk is regressions in display formatting/flag interactions.
> 
> **Overview**
> Adds a new `-n`/`--limit` CLI option (default `3`, min `1`) to cap definitions shown per part of speech in normal mode, printing an overflow hint like `(+N more, use -d for all)`; `--detail` now explicitly overrides this limit and shows full output.
> 
> Refactors output control behind `DisplayOptions` and a `lookup_and_display()` helper, URL-encodes lookup terms via the new `urlencoding` dependency, and makes interactive mode exit handling and `stdout().flush()` failures graceful.
> 
> Updates docs (`README.md`, `CLAUDE.md`) and tests to cover the new flag combinations and expanded API response fields (e.g., `license`, `sourceUrls`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c14d5d204ea705589e58b9264404ea4104cf06cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated CLI documentation with interactive mode guidance and a new limit option to control definition output per part of speech
- Enhanced API reference documentation with expanded field descriptions and metadata information
- Refreshed usage examples and output samples to reflect updated default behavior and comprehensive content coverage
- Improved overall formatting and clarity throughout documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->